### PR TITLE
Handle titles that are completely in Japanese

### DIFF
--- a/claat/parser/gdoc/parse.go
+++ b/claat/parser/gdoc/parse.go
@@ -819,6 +819,11 @@ func slug(s string) string {
 			dash = true
 		}
 	}
+
+	if buf.Len() == 0 {
+		buf.WriteString("generic-slug")
+	}
+
 	return buf.String()
 }
 


### PR DESCRIPTION
Deployed as version `20180315t091157` for [qwiklabs-publishing-tools](https://pantheon.corp.google.com/appengine/versions?project=qwiklabs-publishing-tools&serviceId=default&organizationId=433637338589&versionssize=50)

Also deployed as version `20180315t091816` for [qwiklab-production](https://pantheon.corp.google.com/appengine/versions?project=qwiklab-production&serviceId=default&versionssize=50)


Feel free to promote both versions after accepting this PR.